### PR TITLE
Adjust Error regex to match errors in the beginning like ERROR 59 (0x…

### DIFF
--- a/RobocopyPS/internal/Invoke-RobocopyParser.ps1
+++ b/RobocopyPS/internal/Invoke-RobocopyParser.ps1
@@ -35,7 +35,7 @@ Function Invoke-RobocopyParser {
         $ErrorFilter = @(
             "The filename, directory name, or volume label syntax is incorrect.",
             "\*\*\*\*\*  You need these to perform Backup copies \(\/B or \/ZB\).",
-            "ERROR \d{1,3} \(0x\d{1,11}\)",
+            "ERROR \d{1,3} \(0x\d\w{1,11}\)",
             "ERROR : ",
             "ERROR: RETRY LIMIT EXCEEDED.",
             "ERROR 123"


### PR DESCRIPTION
…0000003B)

Need more information when error occurs. ERROR: RETRY LIMIT EXCEEDED is not enough. Suppose to catch first error when it occurs in the output.